### PR TITLE
Record Pearl marketplace deployment addresses

### DIFF
--- a/scripts/deployment/globals_gnosis_mainnet_pearl_beta_new_marketplace5.json
+++ b/scripts/deployment/globals_gnosis_mainnet_pearl_beta_new_marketplace5.json
@@ -20,7 +20,7 @@
   "requesterActivityCheckerAddress": "0x72C7A5E1b684966C3326c86A7D27c7C570Cc4DAC",
   "stakingFactoryAddress": "0xb0228CA253A88Bc8eb4ca70BCAC8f87b381f4700",
   "stakingParams": {
-    "metadataHash": "",
+    "metadataHash": "0xadb514bdafa1910bbc419b682edea00525b5e0651f84a38e9ac2c1d6174f2cf6",
     "maxNumServices": "50",
     "rewardsPerSecond": "317097919837646",
     "minStakingDeposit": "5000000000000000000000",
@@ -38,5 +38,5 @@
     "serviceRegistry": "0x9338b5153AE39BB89f50468E608eD9d764B755fD",
     "activityChecker": "0x72C7A5E1b684966C3326c86A7D27c7C570Cc4DAC"
   },
-  "stakingTokenInstanceAddress": ""
+  "stakingTokenInstanceAddress": "0x536D04dBD9A2310152a0D2d8D18daDFCA8Bb26b0"
 }

--- a/scripts/deployment/globals_gnosis_mainnet_pearl_beta_new_marketplace6.json
+++ b/scripts/deployment/globals_gnosis_mainnet_pearl_beta_new_marketplace6.json
@@ -20,7 +20,7 @@
   "requesterActivityCheckerAddress": "0x72C7A5E1b684966C3326c86A7D27c7C570Cc4DAC",
   "stakingFactoryAddress": "0xb0228CA253A88Bc8eb4ca70BCAC8f87b381f4700",
   "stakingParams": {
-    "metadataHash": "",
+    "metadataHash": "0x721eec01e10fcaadb6e3c6cdb3e577055b4f89588799ec35b0786e67c2fb3030",
     "maxNumServices": "50",
     "rewardsPerSecond": "317097919837646",
     "minStakingDeposit": "5000000000000000000000",
@@ -38,5 +38,5 @@
     "serviceRegistry": "0x9338b5153AE39BB89f50468E608eD9d764B755fD",
     "activityChecker": "0x72C7A5E1b684966C3326c86A7D27c7C570Cc4DAC"
   },
-  "stakingTokenInstanceAddress": ""
+  "stakingTokenInstanceAddress": "0xac3Ed39D18d9C951BD2e7F0024114849C0a25295"
 }

--- a/scripts/deployment/globals_gnosis_mainnet_pearl_beta_new_marketplace7.json
+++ b/scripts/deployment/globals_gnosis_mainnet_pearl_beta_new_marketplace7.json
@@ -20,7 +20,7 @@
   "requesterActivityCheckerAddress": "0x72C7A5E1b684966C3326c86A7D27c7C570Cc4DAC",
   "stakingFactoryAddress": "0xb0228CA253A88Bc8eb4ca70BCAC8f87b381f4700",
   "stakingParams": {
-    "metadataHash": "",
+    "metadataHash": "0x7958eb9c4159c1e872e2807012f22b4e4692cc48e57443cf646d1367ba4bc438",
     "maxNumServices": "50",
     "rewardsPerSecond": "317097919837646",
     "minStakingDeposit": "5000000000000000000000",
@@ -38,5 +38,5 @@
     "serviceRegistry": "0x9338b5153AE39BB89f50468E608eD9d764B755fD",
     "activityChecker": "0x72C7A5E1b684966C3326c86A7D27c7C570Cc4DAC"
   },
-  "stakingTokenInstanceAddress": ""
+  "stakingTokenInstanceAddress": "0xB2303F9913f11131A74F4b05099Ced2043cc72C4"
 }

--- a/scripts/deployment/globals_gnosis_mainnet_pearl_beta_new_marketplace8.json
+++ b/scripts/deployment/globals_gnosis_mainnet_pearl_beta_new_marketplace8.json
@@ -20,7 +20,7 @@
   "requesterActivityCheckerAddress": "0x95b37c45BADAf4668c18d00501948196761736b1",
   "stakingFactoryAddress": "0xb0228CA253A88Bc8eb4ca70BCAC8f87b381f4700",
   "stakingParams": {
-    "metadataHash": "",
+    "metadataHash": "0xa6711057c88342ce14b40f5e1bd06541c127d3f4b35cb0a990cbc84847823e9b",
     "maxNumServices": "50",
     "rewardsPerSecond": "158548959918823",
     "minStakingDeposit": "2500000000000000000000",
@@ -38,5 +38,5 @@
     "serviceRegistry": "0x9338b5153AE39BB89f50468E608eD9d764B755fD",
     "activityChecker": "0x95b37c45BADAf4668c18d00501948196761736b1"
   },
-  "stakingTokenInstanceAddress": ""
+  "stakingTokenInstanceAddress": "0x12bdd401Ac300482f4017C64c6c930ee40424c08"
 }


### PR DESCRIPTION
## Summary
- record deployed staking instance addresses for Pearl Beta Mech Marketplace V-VIII
- record on-chain metadata hashes for the same four deployed staking contracts

## Verification
- node scripts/audit_staking_setups/audit_setup.js --config scripts/deployment/globals_gnosis_mainnet_pearl_beta_new_marketplace5.json --config scripts/deployment/globals_gnosis_mainnet_pearl_beta_new_marketplace6.json --config scripts/deployment/globals_gnosis_mainnet_pearl_beta_new_marketplace7.json --config scripts/deployment/globals_gnosis_mainnet_pearl_beta_new_marketplace8.json
- Result: On-chain staking instrances checks: 4; Activity checker checks: 4; Mismatches: 0; Warnings: 0; Errors: 0; Skipped: 0