### PR TITLE
feat: RequesterActivityCheckerV2 (drop Safe-nonce guard for off-chain mech delivery)

### DIFF
--- a/contracts/mech_usage/RequesterActivityCheckerV2.sol
+++ b/contracts/mech_usage/RequesterActivityCheckerV2.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {StakingActivityChecker} from "../../lib/autonolas-registries/contracts/staking/StakingActivityChecker.sol";
+
+// Multisig interface
+interface IMultisig {
+    /// @dev Gets the multisig nonce.
+    /// @return Multisig nonce.
+    function nonce() external view returns (uint256);
+}
+
+// Mech Marketplace interface
+interface IMechMarketplace {
+    /// @dev Gets the requests count for a specific requester account.
+    /// @param requester Requester address.
+    /// @return requestsCount Requests count.
+    function mapRequestCounts(address requester) external view returns (uint256 requestsCount);
+}
+
+/// @dev Provided zero address.
+error ZeroAddress();
+
+/// @title RequesterActivityCheckerV2 - Smart contract for requester staking activity checking
+/// @author Aleksandr Kuperman - <aleksandr.kuperman@valory.xyz>
+/// @author Andrey Lebedev - <andrey.lebedev@valory.xyz>
+/// @author Mariapia Moscatiello - <mariapia.moscatiello@valory.xyz>
+/// @notice Drop-in replacement for RequesterActivityChecker. The activity signal is the mech requests
+///         count alone (mapRequestCounts), and the Safe-nonce side of the V1 activity guard is removed.
+///
+///         Rationale: under the off-chain delivery path (deliver-with-signature) a whole multisend of
+///         mech requests settles against a single Safe nonce flip, so the V1 requirement that the
+///         requests-count delta be backed one-for-one by Safe-nonce deltas can never be met. The
+///         anti-gaming role of that guard is already enforced by the marketplace itself: every increment
+///         to mapRequestCounts goes through Safe-signature verification, a monotonic per-requester nonce
+///         (replay protection), and a real USDC charge at settle. The dropped check is therefore redundant.
+///
+///         V2 is strictly weaker than V1: anything that passed V1 also passes V2 with identical behaviour
+///         at the threshold (on the on-chain path diffNonces >= diffRequestsCounts holds by construction,
+///         so the dropped guards never bound). getMultisigNonces is unchanged - it still returns the
+///         length-2 array [multisig.nonce(), mapRequestCounts(multisig)] so downstream consumers
+///         (frontends, indexers, scripts, events) keep working; index 0 is informational only and is no
+///         longer referenced inside isRatioPass.
+contract RequesterActivityCheckerV2 is StakingActivityChecker {
+    // AI agent mech marketplace contract address.
+    address public immutable mechMarketplace;
+
+    /// @dev RequesterActivityCheckerV2 constructor.
+    /// @param _mechMarketplace AI agent mech marketplace contract address.
+    /// @param _livenessRatio Liveness ratio in the format of 1e18.
+    constructor(address _mechMarketplace, uint256 _livenessRatio) StakingActivityChecker(_livenessRatio) {
+        if (_mechMarketplace == address(0)) {
+            revert ZeroAddress();
+        }
+        mechMarketplace = _mechMarketplace;
+    }
+
+    /// @dev Gets service multisig nonces.
+    /// @notice Index 0 (the Safe nonce) is kept for ABI compatibility with downstream consumers and is
+    ///         informational only; the liveness check relies on index 1 (the requests count) alone.
+    /// @param multisig Service multisig address.
+    /// @return nonces Set of a nonce and a requests count for the multisig.
+    function getMultisigNonces(address multisig) external view virtual override returns (uint256[] memory nonces) {
+        nonces = new uint256[](2);
+        nonces[0] = IMultisig(multisig).nonce();
+        nonces[1] = IMechMarketplace(mechMarketplace).mapRequestCounts(multisig);
+    }
+
+    /// @dev Checks if the service multisig liveness ratio passes the defined liveness threshold.
+    /// @notice The formula for calculating the ratio is the following:
+    ///         currentNonces - [service multisig nonce at time now (block.timestamp), requests count at time now];
+    ///         lastNonces - [service multisig nonce at the previous checkpoint or staking time (tsStart), requests count at time tsStart];
+    ///         ratio = (currentNonces[1] - lastNonces[1]) / (block.timestamp - tsStart),
+    ///         where ratio >= livenessRatio.
+    ///         Unlike V1, the requests-count delta is not required to be backed by the Safe-nonce delta;
+    ///         the requests count (index 1) alone determines the activity signal.
+    /// @param curNonces Current service multisig set of nonce and requests count.
+    /// @param lastNonces Last service multisig set of nonce and requests count.
+    /// @param ts Time difference between current and last timestamps.
+    /// @return ratioPass True, if the liveness ratio passes the check.
+    function isRatioPass(
+        uint256[] memory curNonces,
+        uint256[] memory lastNonces,
+        uint256 ts
+    ) external view virtual override returns (bool ratioPass)
+    {
+        // If the checkpoint was called in the exact same block, the ratio is zero
+        // If the current requests count is not greater than the last requests count, the ratio is zero
+        if (ts > 0 && curNonces[1] > lastNonces[1]) {
+            uint256 diffRequestsCounts = curNonces[1] - lastNonces[1];
+            uint256 ratio = (diffRequestsCounts * 1e18) / ts;
+            ratioPass = (ratio >= livenessRatio);
+        }
+    }
+}

--- a/scripts/deployment/deploy_06_requester_activity_checker_v2.sh
+++ b/scripts/deployment/deploy_06_requester_activity_checker_v2.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# Get globals file
+globals="$(dirname "$0")/globals_$1.json"
+if [ ! -f $globals ]; then
+  echo "!!! $globals is not found"
+  exit 0
+fi
+
+# Read variables using jq
+contractVerification=$(jq -r '.contractVerification' $globals)
+useLedger=$(jq -r '.useLedger' $globals)
+derivationPath=$(jq -r '.derivationPath' $globals)
+chainId=$(jq -r '.chainId' $globals)
+networkURL=$(jq -r '.networkURL' $globals)
+
+# Check for Alchemy keys on ETH, Polygon mainnets and testnets
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "${red}!!! Set $keyName env variable${reset}"
+    exit 0
+  fi
+fi
+
+mechMarketplaceAddress=$(jq -r '.mechMarketplaceAddress' $globals)
+livenessRatio=$(jq -r '.livenessRatio' $globals)
+
+contractName="RequesterActivityCheckerV2"
+contractPath="contracts/mech_usage/$contractName.sol:$contractName"
+constructorArgs="$mechMarketplaceAddress $livenessRatio"
+contractArgs="$contractPath --constructor-args $constructorArgs"
+
+
+# Get deployer based on the ledger flag
+if [ "$useLedger" == "true" ]; then
+  walletArgs="-l --mnemonic-derivation-path $derivationPath"
+  deployer=$(cast wallet address $walletArgs)
+else
+  echo "Using PRIVATE_KEY: ${PRIVATE_KEY:0:6}..."
+  walletArgs="--private-key $PRIVATE_KEY"
+  deployer=$(cast wallet address $walletArgs)
+fi
+
+# Deployment message
+echo "Deploying from: $deployer"
+echo "Deployment of: $contractArgs"
+
+# Deploy the contract and capture the address
+execCmd="forge create --broadcast --rpc-url $networkURL$API_KEY $walletArgs $contractArgs"
+deploymentOutput=$($execCmd)
+requesterActivityCheckerAddress=$(echo "$deploymentOutput" | grep 'Deployed to:' | awk '{print $3}')
+
+# Get output length
+outputLength=${#requesterActivityCheckerAddress}
+
+# Check for the deployed address
+if [ $outputLength != 42 ]; then
+  echo "!!! The contract was not deployed"
+  exit 0
+fi
+
+# Write new deployed contract back into JSON
+echo "$(jq '. += {"requesterActivityCheckerAddress":"'$requesterActivityCheckerAddress'"}' $globals)" > $globals
+
+# Verify contract
+if [ "$contractVerification" == "true" ]; then
+  contractParams="$requesterActivityCheckerAddress $contractPath --constructor-args $(cast abi-encode "constructor(address,uint256)" $constructorArgs)"
+
+  echo "Verifying contract on Etherscan..."
+  forge verify-contract --chain-id "$chainId" --etherscan-api-key "$ETHERSCAN_API_KEY" $contractParams
+
+  blockscoutURL=$(jq -r '.blockscoutURL' $globals)
+  if [ "$blockscoutURL" != "null" ]; then
+    echo "Verifying contract on Blockscout..."
+    forge verify-contract --verifier blockscout --verifier-url "$blockscoutURL/api" $contractParams
+  fi
+fi
+
+echo "$contractName deployed at: $requesterActivityCheckerAddress"

--- a/test/RequesterActivityCheckerV2.t.sol
+++ b/test/RequesterActivityCheckerV2.t.sol
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Test} from "forge-std/Test.sol";
+import {RequesterActivityChecker} from "../contracts/mech_usage/RequesterActivityChecker.sol";
+import {RequesterActivityCheckerV2} from "../contracts/mech_usage/RequesterActivityCheckerV2.sol";
+import {MockAgentMech} from "../contracts/test/MockAgentMech.sol";
+
+/// @dev Minimal multisig exposing the Safe-style nonce() getter used by getMultisigNonces.
+contract MockMultisig {
+    uint256 public nonce;
+
+    function setNonce(uint256 newNonce) external {
+        nonce = newNonce;
+    }
+}
+
+/// @title RequesterActivityCheckerV2Test - Unit tests isolating the V1 -> V2 behavioural change.
+/// @notice The only logic difference between V1 and V2 is inside isRatioPass: V2 drops the Safe-nonce
+///         precondition and the (diffRequestsCounts <= diffNonces) parity guard, keeping the ratio math
+///         identical. These tests exercise isRatioPass directly with crafted nonce arrays so the change
+///         is provable without the full staking/Safe integration harness.
+contract RequesterActivityCheckerV2Test is Test {
+    RequesterActivityChecker internal v1;
+    RequesterActivityCheckerV2 internal v2;
+    MockAgentMech internal marketplace;
+
+    // Same magnitude as production configs: one request per 1e4 seconds (~2.78h) clears the threshold.
+    uint256 internal constant LIVENESS_RATIO = 0.0001 ether; // 1e14
+
+    function setUp() public {
+        marketplace = new MockAgentMech();
+        v1 = new RequesterActivityChecker(address(marketplace), LIVENESS_RATIO);
+        v2 = new RequesterActivityCheckerV2(address(marketplace), LIVENESS_RATIO);
+    }
+
+    /// @dev Builds a length-2 [nonce, requestsCount] array.
+    function _nonces(uint256 safeNonce, uint256 requestsCount) internal pure returns (uint256[] memory arr) {
+        arr = new uint256[](2);
+        arr[0] = safeNonce;
+        arr[1] = requestsCount;
+    }
+
+    /// @dev The gap V2 closes: off-chain path where the Safe nonce did not advance but requests landed.
+    ///      V1 fails on the curNonces[0] > lastNonces[0] precondition; V2 passes on the request count alone.
+    function test_OffchainPath_V1Fails_V2Passes() external view {
+        // Safe nonce unchanged (5 -> 5), 10 mech requests settled off-chain (0 -> 10)
+        uint256[] memory last = _nonces(5, 0);
+        uint256[] memory cur = _nonces(5, 10);
+        uint256 ts = 1 days; // ratio = 10 * 1e18 / 86400 = 1.157e14 >= 1e14
+
+        assertFalse(v1.isRatioPass(cur, last, ts), "V1 must fail when the Safe nonce did not advance");
+        assertTrue(v2.isRatioPass(cur, last, ts), "V2 must pass on requests count alone");
+    }
+
+    /// @dev No regression: an on-chain pattern that passes V1 (each request backed by a Safe tx) passes V2 identically.
+    function test_OnchainPath_BothPass() external view {
+        // 10 Safe txs and 10 requests in the same window: diffNonces == diffRequestsCounts
+        uint256[] memory last = _nonces(0, 0);
+        uint256[] memory cur = _nonces(10, 10);
+        uint256 ts = 1 days;
+
+        assertTrue(v1.isRatioPass(cur, last, ts), "V1 should pass on the on-chain path");
+        assertTrue(v2.isRatioPass(cur, last, ts), "V2 should pass identically on the on-chain path");
+    }
+
+    /// @dev On-chain pattern below the liveness threshold fails both, identically.
+    function test_OnchainPath_BelowThreshold_BothFail() external view {
+        // 1 request over a full day: ratio = 1 * 1e18 / 86400 = 1.157e13 < 1e14
+        uint256[] memory last = _nonces(0, 0);
+        uint256[] memory cur = _nonces(1, 1);
+        uint256 ts = 1 days;
+
+        assertFalse(v1.isRatioPass(cur, last, ts), "V1 should fail below threshold");
+        assertFalse(v2.isRatioPass(cur, last, ts), "V2 should fail identically below threshold");
+    }
+
+    /// @dev Behaviour at the exact threshold matches between V1 and V2 (ratio == livenessRatio passes; one second more fails).
+    function test_ThresholdBoundary_Identical() external view {
+        // ratio == livenessRatio exactly: 1 request, ts = 1e18 / 1e14 = 1e4 seconds
+        uint256[] memory last = _nonces(0, 0);
+        uint256[] memory cur = _nonces(1, 1);
+        uint256 tsAtThreshold = 1e4;
+        assertTrue(v1.isRatioPass(cur, last, tsAtThreshold), "V1 passes at the threshold");
+        assertTrue(v2.isRatioPass(cur, last, tsAtThreshold), "V2 passes at the threshold");
+
+        // One second past the threshold window: ratio drops just below livenessRatio
+        uint256 tsPastThreshold = 1e4 + 1;
+        assertFalse(v1.isRatioPass(cur, last, tsPastThreshold), "V1 fails just past the threshold");
+        assertFalse(v2.isRatioPass(cur, last, tsPastThreshold), "V2 fails just past the threshold");
+    }
+
+    /// @dev No new requests -> both fail regardless of how many Safe txs were sent.
+    function test_NoNewRequests_BothFail() external view {
+        uint256[] memory last = _nonces(5, 5);
+        uint256[] memory cur = _nonces(9, 5); // nonce advanced, request count flat
+        uint256 ts = 1 days;
+
+        assertFalse(v1.isRatioPass(cur, last, ts), "V1 must fail with no new requests");
+        assertFalse(v2.isRatioPass(cur, last, ts), "V2 must fail with no new requests");
+    }
+
+    /// @dev Same-block checkpoint (ts == 0) -> both fail.
+    function test_ZeroTimeDelta_BothFail() external view {
+        uint256[] memory last = _nonces(0, 0);
+        uint256[] memory cur = _nonces(10, 10);
+
+        assertFalse(v1.isRatioPass(cur, last, 0), "V1 must fail with zero time delta");
+        assertFalse(v2.isRatioPass(cur, last, 0), "V2 must fail with zero time delta");
+    }
+
+    /// @dev V2 is strictly weaker than V1: anything that passes V1 must also pass V2.
+    function testFuzz_V1PassImpliesV2Pass(
+        uint256 lastNonce,
+        uint256 lastReq,
+        uint256 deltaNonce,
+        uint256 deltaReq,
+        uint256 ts
+    ) external view {
+        // Bound to realistic ranges and to avoid the diffRequestsCounts * 1e18 overflow
+        lastNonce = bound(lastNonce, 0, 1e12);
+        lastReq = bound(lastReq, 0, 1e12);
+        deltaNonce = bound(deltaNonce, 0, 1e12);
+        deltaReq = bound(deltaReq, 0, 1e12);
+        ts = bound(ts, 0, 1e12);
+
+        uint256[] memory last = _nonces(lastNonce, lastReq);
+        uint256[] memory cur = _nonces(lastNonce + deltaNonce, lastReq + deltaReq);
+
+        if (v1.isRatioPass(cur, last, ts)) {
+            assertTrue(v2.isRatioPass(cur, last, ts), "every V1 pass must also pass V2");
+        }
+    }
+
+    /// @dev ABI compatibility: getMultisigNonces keeps the length-2 [nonce, requestsCount] shape in V2.
+    ///      This is the off-chain compatibility contract - downstream consumers read requests at index 1.
+    function test_GetMultisigNonces_ShapeAndValuesIdentical() external {
+        MockMultisig multisig = new MockMultisig();
+        multisig.setNonce(42);
+        // Bump the marketplace request counter for this multisig to 7
+        for (uint256 i = 0; i < 7; ++i) {
+            marketplace.increaseRequestsCount(address(multisig));
+        }
+
+        uint256[] memory n1 = v1.getMultisigNonces(address(multisig));
+        uint256[] memory n2 = v2.getMultisigNonces(address(multisig));
+
+        assertEq(n1.length, 2, "V1 must return a length-2 array");
+        assertEq(n2.length, 2, "V2 must keep the length-2 array shape");
+        assertEq(n2[0], 42, "index 0 stays the Safe nonce (informational)");
+        assertEq(n2[1], 7, "index 1 stays the requests count (activity signal)");
+        assertEq(n1[0], n2[0], "Safe nonce must match V1");
+        assertEq(n1[1], n2[1], "requests count must match V1");
+    }
+}


### PR DESCRIPTION
## Summary

Adds `RequesterActivityCheckerV2` — a drop-in replacement for `RequesterActivityChecker` that makes staking liveness compatible with the off-chain mech delivery path (deliver-with-signature), plus its deployment script and unit tests.

> Stacked on top of #144 (`feat/base-optimus-staking-basius`). Base will auto-retarget to `main` once #144 merges.

## Problem

A staked requester (Trader, pearl-mini, Optimus, …) is checked at each staking checkpoint against two deltas: Safe transactions sent vs. mech requests made, with the rule `diffRequestsCounts <= diffNonces`. Under the off-chain path a whole multisend of requests settles against a **single** Safe nonce flip, so `diffNonces = 0` while `diffRequestsCounts > 0` — the constraint can never be met and agents can't hit staking KPIs.

## Change

The only logic change is inside `isRatioPass`:
- drop the `curNonces[0] > lastNonces[0]` precondition
- drop the `diffNonces` computation
- drop the `diffRequestsCounts <= diffNonces` parity guard
- keep the ratio math identical: pass when `(diffRequestsCounts * 1e18) / ts >= livenessRatio`

`getMultisigNonces` is **unchanged** — still returns the length-2 `[multisig.nonce(), mapRequestCounts(multisig)]` so downstream consumers (frontends, indexers, scripts, the `RewardClaimed`/`Checkpoint` events) keep reading the request count at index 1. Index 0 becomes informational only.

## Why it's safe

- **Strictly weaker than V1:** on the on-chain path `diffNonces >= diffRequestsCounts` holds by construction, so the dropped guards never bound. Anything that passed V1 passes V2 identically at the threshold — no regression for on-chain agents.
- **Anti-gaming preserved by the marketplace:** every `mapRequestCounts` increment goes through `_deliverMarketplaceWithSignatures` — Safe-signature verification, a monotonic per-requester nonce (replay protection), and a real USDC charge at settle. The dropped parity check was redundant belt-and-suspenders.

## Tests (`test/RequesterActivityCheckerV2.t.sol`, 8 tests, all passing)

Each test runs V1 and V2 side by side:
- off-chain gap closed (V1 fails, V2 passes)
- on-chain no-regression (both pass identically)
- below-threshold both fail; exact-threshold boundary identical
- no-new-requests / zero-time-delta both fail
- fuzz: every V1 pass implies a V2 pass (strictly weaker)
- `getMultisigNonces` ABI shape + values identical to V1

Local verification: `forge test --hh` → 21 passed / 0 failed; `hardhat compile` → ok.

## Deployment

`scripts/deployment/deploy_06_requester_activity_checker_v2.sh` mirrors the V1 `deploy_06` script (identical `(address mechMarketplace, uint256 livenessRatio)` constructor); run as:

```bash
./scripts/deployment/deploy_06_requester_activity_checker_v2.sh <network_config_suffix>
```

## Migration note

`activityChecker` is immutable per staking instance, so every staking program currently on V1 needs a **new instance** pointing at a deployed V2 — on-chain staked deployments included, not just the ones moving off-chain.