### PR TITLE
feat: add VERSION 0.2.0 to RequesterActivityCheckerV2

### DIFF
--- a/contracts/mech_usage/RequesterActivityCheckerV2.sol
+++ b/contracts/mech_usage/RequesterActivityCheckerV2.sol
@@ -42,6 +42,8 @@ error ZeroAddress();
 ///         (frontends, indexers, scripts, events) keep working; index 0 is informational only and is no
 ///         longer referenced inside isRatioPass.
 contract RequesterActivityCheckerV2 is StakingActivityChecker {
+    // Version number
+    string public constant VERSION = "0.2.0";
     // AI agent mech marketplace contract address.
     address public immutable mechMarketplace;
 

--- a/test/RequesterActivityCheckerV2.t.sol
+++ b/test/RequesterActivityCheckerV2.t.sol
@@ -41,6 +41,11 @@ contract RequesterActivityCheckerV2Test is Test {
         arr[1] = requestsCount;
     }
 
+    /// @dev VERSION constant is the expected V2 value.
+    function test_Version() external view {
+        assertEq(v2.VERSION(), "0.2.0", "unexpected VERSION");
+    }
+
     /// @dev The gap V2 closes: off-chain path where the Safe nonce did not advance but requests landed.
     ///      V1 fails on the curNonces[0] > lastNonces[0] precondition; V2 passes on the request count alone.
     function test_OffchainPath_V1Fails_V2Passes() external view {


### PR DESCRIPTION
Adds a `VERSION` constant to `RequesterActivityCheckerV2`, matching the repo convention (`string public constant VERSION`, as in StakingBase / Contributors).

```solidity
// Version number
string public constant VERSION = "0.2.0";
```

### Why 0.2.0
- **Pre-1.0 (MAJOR 0):** consistent with the rest of the staking surface (StakingBase `0.2.0`, Contributors `0.2.0`, StakingAirdrop `0.1.0`).
- **MINOR 2:** V1 `RequesterActivityChecker` was the unversioned first cut (effectively `0.1.0`). V2 changes behaviour (drops the Safe-nonce parity guard) but keeps a backward-compatible interface (same constructor, `IActivityChecker` conformance, length-2 `getMultisigNonces`) — a minor bump, not major. Also mirrors the V2 name and the Contributors v2 = `0.2.0` precedent.
- **PATCH 0:** initial release of this version.

The inherited `StakingActivityChecker` base declares no `VERSION`, so there's no override/clash. Added `test_Version` to lock the value; full suite green (`forge test --hh` 9/9 on the V2 file).