### PR TITLE
chore: wire V2 checkers + record deployed staking instances (Omenstrat/Optimus/Polystrat/Basius)

### DIFF
--- a/scripts/deployment/globals_base_mainnet_basius1.json
+++ b/scripts/deployment/globals_base_mainnet_basius1.json
@@ -36,7 +36,7 @@
     "configHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "proxyHash": "0xb89c1b3bdf2cf8827818646bce9a8f6e372885f8c55e5c07acbd307cb133b000",
     "serviceRegistry": "0x3C1fF68f5aa342D296d4DEe4Bb1cACCA912D95fE",
-    "activityChecker": ""
+    "activityChecker": "0xE73C4e90983aa65d42b2de968E0C8F25Ced835A8"
   },
   "stakingTokenInstanceAddress": ""
 }

--- a/scripts/deployment/globals_base_mainnet_basius1.json
+++ b/scripts/deployment/globals_base_mainnet_basius1.json
@@ -20,7 +20,7 @@
   "requesterActivityCheckerAddress": "0xE73C4e90983aa65d42b2de968E0C8F25Ced835A8",
   "stakingFactoryAddress": "0x1cEe30D08943EB58EFF84DD1AB44a6ee6FEff63a",
   "stakingParams": {
-    "metadataHash": "",
+    "metadataHash": "0x51df668c70907d4df4003efb8d0f85c60eb364f463c5065a6869c416f5f7dfd1",
     "maxNumServices": "20",
     "rewardsPerSecond": "158548959919",
     "minStakingDeposit": "50000000000000000000",
@@ -38,5 +38,5 @@
     "serviceRegistry": "0x3C1fF68f5aa342D296d4DEe4Bb1cACCA912D95fE",
     "activityChecker": "0xE73C4e90983aa65d42b2de968E0C8F25Ced835A8"
   },
-  "stakingTokenInstanceAddress": ""
+  "stakingTokenInstanceAddress": "0x0fB55CEf7B12B76ea52900325461a5443F51B43F"
 }

--- a/scripts/deployment/globals_base_mainnet_basius2.json
+++ b/scripts/deployment/globals_base_mainnet_basius2.json
@@ -20,7 +20,7 @@
   "requesterActivityCheckerAddress": "0xE73C4e90983aa65d42b2de968E0C8F25Ced835A8",
   "stakingFactoryAddress": "0x1cEe30D08943EB58EFF84DD1AB44a6ee6FEff63a",
   "stakingParams": {
-    "metadataHash": "",
+    "metadataHash": "0x75aead4f1e67bc54fd02d9cca3fb2aa993d3f26cb20d809637a6bad1faeb9d7d",
     "maxNumServices": "40",
     "rewardsPerSecond": "1585489599188",
     "minStakingDeposit": "500000000000000000000",
@@ -38,5 +38,5 @@
     "serviceRegistry": "0x3C1fF68f5aa342D296d4DEe4Bb1cACCA912D95fE",
     "activityChecker": "0xE73C4e90983aa65d42b2de968E0C8F25Ced835A8"
   },
-  "stakingTokenInstanceAddress": ""
+  "stakingTokenInstanceAddress": "0x728ca3b024Ba4c273695Df6e45e79DB675B8c756"
 }

--- a/scripts/deployment/globals_base_mainnet_basius2.json
+++ b/scripts/deployment/globals_base_mainnet_basius2.json
@@ -17,7 +17,7 @@
   "stakingTokenAddress": "0xEB5638eefE289691EcE01943f768EDBF96258a80",
   "mechMarketplaceAddress": "0xf24eE42edA0fc9b33B7D41B06Ee8ccD2Ef7C5020",
   "livenessRatio": "11337868480725",
-  "requesterActivityCheckerAddress": "",
+  "requesterActivityCheckerAddress": "0xE73C4e90983aa65d42b2de968E0C8F25Ced835A8",
   "stakingFactoryAddress": "0x1cEe30D08943EB58EFF84DD1AB44a6ee6FEff63a",
   "stakingParams": {
     "metadataHash": "",
@@ -36,7 +36,7 @@
     "configHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "proxyHash": "0xb89c1b3bdf2cf8827818646bce9a8f6e372885f8c55e5c07acbd307cb133b000",
     "serviceRegistry": "0x3C1fF68f5aa342D296d4DEe4Bb1cACCA912D95fE",
-    "activityChecker": ""
+    "activityChecker": "0xE73C4e90983aa65d42b2de968E0C8F25Ced835A8"
   },
   "stakingTokenInstanceAddress": ""
 }

--- a/scripts/deployment/globals_base_mainnet_basius3.json
+++ b/scripts/deployment/globals_base_mainnet_basius3.json
@@ -17,7 +17,7 @@
   "stakingTokenAddress": "0xEB5638eefE289691EcE01943f768EDBF96258a80",
   "mechMarketplaceAddress": "0xf24eE42edA0fc9b33B7D41B06Ee8ccD2Ef7C5020",
   "livenessRatio": "11337868480725",
-  "requesterActivityCheckerAddress": "",
+  "requesterActivityCheckerAddress": "0xE73C4e90983aa65d42b2de968E0C8F25Ced835A8",
   "stakingFactoryAddress": "0x1cEe30D08943EB58EFF84DD1AB44a6ee6FEff63a",
   "stakingParams": {
     "metadataHash": "",
@@ -36,7 +36,7 @@
     "configHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "proxyHash": "0xb89c1b3bdf2cf8827818646bce9a8f6e372885f8c55e5c07acbd307cb133b000",
     "serviceRegistry": "0x3C1fF68f5aa342D296d4DEe4Bb1cACCA912D95fE",
-    "activityChecker": ""
+    "activityChecker": "0xE73C4e90983aa65d42b2de968E0C8F25Ced835A8"
   },
   "stakingTokenInstanceAddress": ""
 }

--- a/scripts/deployment/globals_base_mainnet_basius3.json
+++ b/scripts/deployment/globals_base_mainnet_basius3.json
@@ -20,7 +20,7 @@
   "requesterActivityCheckerAddress": "0xE73C4e90983aa65d42b2de968E0C8F25Ced835A8",
   "stakingFactoryAddress": "0x1cEe30D08943EB58EFF84DD1AB44a6ee6FEff63a",
   "stakingParams": {
-    "metadataHash": "",
+    "metadataHash": "0xb20a87f1658efd0f999914efcb1f223fccdf63622e4c5960593c2399d6c0a90b",
     "maxNumServices": "40",
     "rewardsPerSecond": "7927447995941",
     "minStakingDeposit": "2500000000000000000000",
@@ -38,5 +38,5 @@
     "serviceRegistry": "0x3C1fF68f5aa342D296d4DEe4Bb1cACCA912D95fE",
     "activityChecker": "0xE73C4e90983aa65d42b2de968E0C8F25Ced835A8"
   },
-  "stakingTokenInstanceAddress": ""
+  "stakingTokenInstanceAddress": "0x9593C4524DF86f46935aa0eC996B4ccBe71c8234"
 }

--- a/scripts/deployment/globals_gnosis_mainnet_omenstrat1.json
+++ b/scripts/deployment/globals_gnosis_mainnet_omenstrat1.json
@@ -19,7 +19,7 @@
   "requesterActivityCheckerAddress": "0x3514EeA47C03dF8d9FdD68A469908755d2870c48",
   "stakingFactoryAddress": "0xb0228CA253A88Bc8eb4ca70BCAC8f87b381f4700",
   "stakingParams": {
-    "metadataHash": "",
+    "metadataHash": "0x9bcbe512a6be173dea2215cf24352e3d68a1a4b2f5315bbfe4f6d68c29cbd0f3",
     "maxNumServices": "50",
     "rewardsPerSecond": "7927447995941",
     "minStakingDeposit": "2500000000000000000000",
@@ -37,5 +37,5 @@
     "serviceRegistry": "0x9338b5153AE39BB89f50468E608eD9d764B755fD",
     "activityChecker": "0x3514EeA47C03dF8d9FdD68A469908755d2870c48"
   },
-  "stakingTokenInstanceAddress": ""
+  "stakingTokenInstanceAddress": "0x1E215da0541B4a77a66e21F17413A877B84Ab129"
 }

--- a/scripts/deployment/globals_gnosis_mainnet_omenstrat1.json
+++ b/scripts/deployment/globals_gnosis_mainnet_omenstrat1.json
@@ -35,7 +35,7 @@
     "configHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "proxyHash": "0xb89c1b3bdf2cf8827818646bce9a8f6e372885f8c55e5c07acbd307cb133b000",
     "serviceRegistry": "0x9338b5153AE39BB89f50468E608eD9d764B755fD",
-    "activityChecker": ""
+    "activityChecker": "0x3514EeA47C03dF8d9FdD68A469908755d2870c48"
   },
   "stakingTokenInstanceAddress": ""
 }

--- a/scripts/deployment/globals_gnosis_mainnet_omenstrat2.json
+++ b/scripts/deployment/globals_gnosis_mainnet_omenstrat2.json
@@ -19,7 +19,7 @@
   "requesterActivityCheckerAddress": "0x3514EeA47C03dF8d9FdD68A469908755d2870c48",
   "stakingFactoryAddress": "0xb0228CA253A88Bc8eb4ca70BCAC8f87b381f4700",
   "stakingParams": {
-    "metadataHash": "",
+    "metadataHash": "0x1ab051ded03521006c50251380931457b395c389d3796431f0dc6c27d56c40db",
     "maxNumServices": "50",
     "rewardsPerSecond": "7927447995941",
     "minStakingDeposit": "2500000000000000000000",
@@ -37,5 +37,5 @@
     "serviceRegistry": "0x9338b5153AE39BB89f50468E608eD9d764B755fD",
     "activityChecker": "0x3514EeA47C03dF8d9FdD68A469908755d2870c48"
   },
-  "stakingTokenInstanceAddress": ""
+  "stakingTokenInstanceAddress": "0xC2BbfC0d2F5a341DcdCc9f3B78FAF7B04f0244ff"
 }

--- a/scripts/deployment/globals_gnosis_mainnet_omenstrat2.json
+++ b/scripts/deployment/globals_gnosis_mainnet_omenstrat2.json
@@ -16,7 +16,7 @@
   "stakingTokenAddress": "0xEa00be6690a871827fAfD705440D20dd75e67AB1",
   "mechMarketplaceAddress": "0x735FAAb1c4Ec41128c367AFb5c3baC73509f70bB",
   "livenessRatio": "11337868480725",
-  "requesterActivityCheckerAddress": "",
+  "requesterActivityCheckerAddress": "0x3514EeA47C03dF8d9FdD68A469908755d2870c48",
   "stakingFactoryAddress": "0xb0228CA253A88Bc8eb4ca70BCAC8f87b381f4700",
   "stakingParams": {
     "metadataHash": "",
@@ -35,7 +35,7 @@
     "configHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "proxyHash": "0xb89c1b3bdf2cf8827818646bce9a8f6e372885f8c55e5c07acbd307cb133b000",
     "serviceRegistry": "0x9338b5153AE39BB89f50468E608eD9d764B755fD",
-    "activityChecker": ""
+    "activityChecker": "0x3514EeA47C03dF8d9FdD68A469908755d2870c48"
   },
   "stakingTokenInstanceAddress": ""
 }

--- a/scripts/deployment/globals_gnosis_mainnet_omenstrat3.json
+++ b/scripts/deployment/globals_gnosis_mainnet_omenstrat3.json
@@ -19,7 +19,7 @@
   "requesterActivityCheckerAddress": "0x3514EeA47C03dF8d9FdD68A469908755d2870c48",
   "stakingFactoryAddress": "0xb0228CA253A88Bc8eb4ca70BCAC8f87b381f4700",
   "stakingParams": {
-    "metadataHash": "",
+    "metadataHash": "0x1d9d1b30198fcf82f9c6592d9655b373ee0424ca1a1646fa67dcf880c201264a",
     "maxNumServices": "100",
     "rewardsPerSecond": "63419583968",
     "minStakingDeposit": "20000000000000000000",
@@ -37,5 +37,5 @@
     "serviceRegistry": "0x9338b5153AE39BB89f50468E608eD9d764B755fD",
     "activityChecker": "0x3514EeA47C03dF8d9FdD68A469908755d2870c48"
   },
-  "stakingTokenInstanceAddress": ""
+  "stakingTokenInstanceAddress": "0xABD4f159a088E7f18FEE8241cF9367f1d746780f"
 }

--- a/scripts/deployment/globals_gnosis_mainnet_omenstrat3.json
+++ b/scripts/deployment/globals_gnosis_mainnet_omenstrat3.json
@@ -16,7 +16,7 @@
   "stakingTokenAddress": "0xEa00be6690a871827fAfD705440D20dd75e67AB1",
   "mechMarketplaceAddress": "0x735FAAb1c4Ec41128c367AFb5c3baC73509f70bB",
   "livenessRatio": "11337868480725",
-  "requesterActivityCheckerAddress": "",
+  "requesterActivityCheckerAddress": "0x3514EeA47C03dF8d9FdD68A469908755d2870c48",
   "stakingFactoryAddress": "0xb0228CA253A88Bc8eb4ca70BCAC8f87b381f4700",
   "stakingParams": {
     "metadataHash": "",
@@ -35,7 +35,7 @@
     "configHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "proxyHash": "0xb89c1b3bdf2cf8827818646bce9a8f6e372885f8c55e5c07acbd307cb133b000",
     "serviceRegistry": "0x9338b5153AE39BB89f50468E608eD9d764B755fD",
-    "activityChecker": ""
+    "activityChecker": "0x3514EeA47C03dF8d9FdD68A469908755d2870c48"
   },
   "stakingTokenInstanceAddress": ""
 }

--- a/scripts/deployment/globals_gnosis_mainnet_omenstrat4.json
+++ b/scripts/deployment/globals_gnosis_mainnet_omenstrat4.json
@@ -19,7 +19,7 @@
   "requesterActivityCheckerAddress": "0x3514EeA47C03dF8d9FdD68A469908755d2870c48",
   "stakingFactoryAddress": "0xb0228CA253A88Bc8eb4ca70BCAC8f87b381f4700",
   "stakingParams": {
-    "metadataHash": "",
+    "metadataHash": "0x24c0cbe2a0acfb68295efc008c59aa34aef62eabf288637cf3592affd9b5e0cc",
     "maxNumServices": "100",
     "rewardsPerSecond": "158548959919",
     "minStakingDeposit": "50000000000000000000",
@@ -37,5 +37,5 @@
     "serviceRegistry": "0x9338b5153AE39BB89f50468E608eD9d764B755fD",
     "activityChecker": "0x3514EeA47C03dF8d9FdD68A469908755d2870c48"
   },
-  "stakingTokenInstanceAddress": ""
+  "stakingTokenInstanceAddress": "0xc9940B9dACA9FDf1B0cD6dE8e3D25ddDC8C9fd0D"
 }

--- a/scripts/deployment/globals_gnosis_mainnet_omenstrat4.json
+++ b/scripts/deployment/globals_gnosis_mainnet_omenstrat4.json
@@ -16,7 +16,7 @@
   "stakingTokenAddress": "0xEa00be6690a871827fAfD705440D20dd75e67AB1",
   "mechMarketplaceAddress": "0x735FAAb1c4Ec41128c367AFb5c3baC73509f70bB",
   "livenessRatio": "11337868480725",
-  "requesterActivityCheckerAddress": "",
+  "requesterActivityCheckerAddress": "0x3514EeA47C03dF8d9FdD68A469908755d2870c48",
   "stakingFactoryAddress": "0xb0228CA253A88Bc8eb4ca70BCAC8f87b381f4700",
   "stakingParams": {
     "metadataHash": "",
@@ -35,7 +35,7 @@
     "configHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "proxyHash": "0xb89c1b3bdf2cf8827818646bce9a8f6e372885f8c55e5c07acbd307cb133b000",
     "serviceRegistry": "0x9338b5153AE39BB89f50468E608eD9d764B755fD",
-    "activityChecker": ""
+    "activityChecker": "0x3514EeA47C03dF8d9FdD68A469908755d2870c48"
   },
   "stakingTokenInstanceAddress": ""
 }

--- a/scripts/deployment/globals_gnosis_mainnet_omenstrat5.json
+++ b/scripts/deployment/globals_gnosis_mainnet_omenstrat5.json
@@ -16,7 +16,7 @@
   "stakingTokenAddress": "0xEa00be6690a871827fAfD705440D20dd75e67AB1",
   "mechMarketplaceAddress": "0x735FAAb1c4Ec41128c367AFb5c3baC73509f70bB",
   "livenessRatio": "11337868480725",
-  "requesterActivityCheckerAddress": "",
+  "requesterActivityCheckerAddress": "0x3514EeA47C03dF8d9FdD68A469908755d2870c48",
   "stakingFactoryAddress": "0xb0228CA253A88Bc8eb4ca70BCAC8f87b381f4700",
   "stakingParams": {
     "metadataHash": "",
@@ -35,7 +35,7 @@
     "configHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "proxyHash": "0xb89c1b3bdf2cf8827818646bce9a8f6e372885f8c55e5c07acbd307cb133b000",
     "serviceRegistry": "0x9338b5153AE39BB89f50468E608eD9d764B755fD",
-    "activityChecker": ""
+    "activityChecker": "0x3514EeA47C03dF8d9FdD68A469908755d2870c48"
   },
   "stakingTokenInstanceAddress": "",
   "name": "Pearl Beta Mech Marketplace V",

--- a/scripts/deployment/globals_gnosis_mainnet_omenstrat5.json
+++ b/scripts/deployment/globals_gnosis_mainnet_omenstrat5.json
@@ -19,7 +19,7 @@
   "requesterActivityCheckerAddress": "0x3514EeA47C03dF8d9FdD68A469908755d2870c48",
   "stakingFactoryAddress": "0xb0228CA253A88Bc8eb4ca70BCAC8f87b381f4700",
   "stakingParams": {
-    "metadataHash": "",
+    "metadataHash": "0xf33649f7b808fd6468af32d02c4df59296c56908998e5748eff6969216127377",
     "maxNumServices": "50",
     "rewardsPerSecond": "15854895991882",
     "minStakingDeposit": "5000000000000000000000",
@@ -37,7 +37,7 @@
     "serviceRegistry": "0x9338b5153AE39BB89f50468E608eD9d764B755fD",
     "activityChecker": "0x3514EeA47C03dF8d9FdD68A469908755d2870c48"
   },
-  "stakingTokenInstanceAddress": "",
+  "stakingTokenInstanceAddress": "0x93aAA7155942700cad74c250263fB2D0c6F72B27",
   "name": "Pearl Beta Mech Marketplace V",
   "description": "This staking contract offers 50 slots for operators running Olas Predict agents interacting with mechs registered on the new marketplace. It requires 10000 OLAS for staking and 16 daily mech calls to meet kpi."
 }

--- a/scripts/deployment/globals_gnosis_mainnet_omenstrat6.json
+++ b/scripts/deployment/globals_gnosis_mainnet_omenstrat6.json
@@ -16,7 +16,7 @@
   "stakingTokenAddress": "0xEa00be6690a871827fAfD705440D20dd75e67AB1",
   "mechMarketplaceAddress": "0x735FAAb1c4Ec41128c367AFb5c3baC73509f70bB",
   "livenessRatio": "11337868480725",
-  "requesterActivityCheckerAddress": "",
+  "requesterActivityCheckerAddress": "0x3514EeA47C03dF8d9FdD68A469908755d2870c48",
   "stakingFactoryAddress": "0xb0228CA253A88Bc8eb4ca70BCAC8f87b381f4700",
   "stakingParams": {
     "metadataHash": "",
@@ -35,7 +35,7 @@
     "configHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "proxyHash": "0xb89c1b3bdf2cf8827818646bce9a8f6e372885f8c55e5c07acbd307cb133b000",
     "serviceRegistry": "0x9338b5153AE39BB89f50468E608eD9d764B755fD",
-    "activityChecker": ""
+    "activityChecker": "0x3514EeA47C03dF8d9FdD68A469908755d2870c48"
   },
   "stakingTokenInstanceAddress": "",
   "name": "Pearl Beta Mech Marketplace VI",

--- a/scripts/deployment/globals_gnosis_mainnet_omenstrat6.json
+++ b/scripts/deployment/globals_gnosis_mainnet_omenstrat6.json
@@ -19,7 +19,7 @@
   "requesterActivityCheckerAddress": "0x3514EeA47C03dF8d9FdD68A469908755d2870c48",
   "stakingFactoryAddress": "0xb0228CA253A88Bc8eb4ca70BCAC8f87b381f4700",
   "stakingParams": {
-    "metadataHash": "",
+    "metadataHash": "0x2e8255b9c0dd39363b3a9ef55e8b21d1b4a0b91b1ed74f58eb538ded07c73330",
     "maxNumServices": "50",
     "rewardsPerSecond": "15854895991882",
     "minStakingDeposit": "5000000000000000000000",
@@ -37,7 +37,7 @@
     "serviceRegistry": "0x9338b5153AE39BB89f50468E608eD9d764B755fD",
     "activityChecker": "0x3514EeA47C03dF8d9FdD68A469908755d2870c48"
   },
-  "stakingTokenInstanceAddress": "",
+  "stakingTokenInstanceAddress": "0xB7ab6F7e6993Df1f0c6A9B177B169Faf4b0C9CCa",
   "name": "Pearl Beta Mech Marketplace VI",
   "description": "This staking contract offers 50 slots for operators running Olas Predict agents interacting with mechs registered on the new marketplace. It requires 10000 OLAS for staking and 16 daily mech calls to meet kpi."
 }

--- a/scripts/deployment/globals_gnosis_mainnet_omenstrat7.json
+++ b/scripts/deployment/globals_gnosis_mainnet_omenstrat7.json
@@ -16,7 +16,7 @@
   "stakingTokenAddress": "0xEa00be6690a871827fAfD705440D20dd75e67AB1",
   "mechMarketplaceAddress": "0x735FAAb1c4Ec41128c367AFb5c3baC73509f70bB",
   "livenessRatio": "11337868480725",
-  "requesterActivityCheckerAddress": "",
+  "requesterActivityCheckerAddress": "0x3514EeA47C03dF8d9FdD68A469908755d2870c48",
   "stakingFactoryAddress": "0xb0228CA253A88Bc8eb4ca70BCAC8f87b381f4700",
   "stakingParams": {
     "metadataHash": "",
@@ -35,7 +35,7 @@
     "configHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "proxyHash": "0xb89c1b3bdf2cf8827818646bce9a8f6e372885f8c55e5c07acbd307cb133b000",
     "serviceRegistry": "0x9338b5153AE39BB89f50468E608eD9d764B755fD",
-    "activityChecker": ""
+    "activityChecker": "0x3514EeA47C03dF8d9FdD68A469908755d2870c48"
   },
   "stakingTokenInstanceAddress": "",
   "name": "Pearl Beta Mech Marketplace VII",

--- a/scripts/deployment/globals_gnosis_mainnet_omenstrat7.json
+++ b/scripts/deployment/globals_gnosis_mainnet_omenstrat7.json
@@ -19,7 +19,7 @@
   "requesterActivityCheckerAddress": "0x3514EeA47C03dF8d9FdD68A469908755d2870c48",
   "stakingFactoryAddress": "0xb0228CA253A88Bc8eb4ca70BCAC8f87b381f4700",
   "stakingParams": {
-    "metadataHash": "",
+    "metadataHash": "0x4f16d6537ed6575a0609f819304bb325c950e8e5b5107eae1ea502d73a608756",
     "maxNumServices": "50",
     "rewardsPerSecond": "15854895991882",
     "minStakingDeposit": "5000000000000000000000",
@@ -37,7 +37,7 @@
     "serviceRegistry": "0x9338b5153AE39BB89f50468E608eD9d764B755fD",
     "activityChecker": "0x3514EeA47C03dF8d9FdD68A469908755d2870c48"
   },
-  "stakingTokenInstanceAddress": "",
+  "stakingTokenInstanceAddress": "0xB801FD1728Eef27418FE03720b1FF3E769F35152",
   "name": "Pearl Beta Mech Marketplace VII",
   "description": "This staking contract offers 50 slots for operators running Olas Predict agents interacting with mechs registered on the new marketplace. It requires 10000 OLAS for staking and 16 daily mech calls to meet kpi."
 }

--- a/scripts/deployment/globals_gnosis_mainnet_omenstrat8.json
+++ b/scripts/deployment/globals_gnosis_mainnet_omenstrat8.json
@@ -16,7 +16,7 @@
   "stakingTokenAddress": "0xEa00be6690a871827fAfD705440D20dd75e67AB1",
   "mechMarketplaceAddress": "0x735FAAb1c4Ec41128c367AFb5c3baC73509f70bB",
   "livenessRatio": "11337868480725",
-  "requesterActivityCheckerAddress": "",
+  "requesterActivityCheckerAddress": "0x3514EeA47C03dF8d9FdD68A469908755d2870c48",
   "stakingFactoryAddress": "0xb0228CA253A88Bc8eb4ca70BCAC8f87b381f4700",
   "stakingParams": {
     "metadataHash": "",
@@ -35,7 +35,7 @@
     "configHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "proxyHash": "0xb89c1b3bdf2cf8827818646bce9a8f6e372885f8c55e5c07acbd307cb133b000",
     "serviceRegistry": "0x9338b5153AE39BB89f50468E608eD9d764B755fD",
-    "activityChecker": ""
+    "activityChecker": "0x3514EeA47C03dF8d9FdD68A469908755d2870c48"
   },
   "stakingTokenInstanceAddress": "",
   "name": "Pearl Beta Mech Marketplace VIII",

--- a/scripts/deployment/globals_optimism_mainnet_optimus1.json
+++ b/scripts/deployment/globals_optimism_mainnet_optimus1.json
@@ -36,7 +36,7 @@
     "configHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "proxyHash": "0xb89c1b3bdf2cf8827818646bce9a8f6e372885f8c55e5c07acbd307cb133b000",
     "serviceRegistry": "0x3d77596beb0f130a4415df3D2D8232B3d3D31e44",
-    "activityChecker": ""
+    "activityChecker": "0x408dCA2b565f5eC7779C181870feFb51Ed67C3F4"
   },
   "stakingTokenInstanceAddress": ""
 }

--- a/scripts/deployment/globals_optimism_mainnet_optimus1.json
+++ b/scripts/deployment/globals_optimism_mainnet_optimus1.json
@@ -20,7 +20,7 @@
   "requesterActivityCheckerAddress": "0x408dCA2b565f5eC7779C181870feFb51Ed67C3F4",
   "stakingFactoryAddress": "0xa45E64d13A30a51b91ae0eb182e88a40e9b18eD8",
   "stakingParams": {
-    "metadataHash": "",
+    "metadataHash": "0x3fd5ca9a80e9c2dd690a719df302f30419075e3075856d20de1a85ba3069d1b3",
     "maxNumServices": "20",
     "rewardsPerSecond": "158548959919",
     "minStakingDeposit": "50000000000000000000",
@@ -38,5 +38,5 @@
     "serviceRegistry": "0x3d77596beb0f130a4415df3D2D8232B3d3D31e44",
     "activityChecker": "0x408dCA2b565f5eC7779C181870feFb51Ed67C3F4"
   },
-  "stakingTokenInstanceAddress": ""
+  "stakingTokenInstanceAddress": "0xCDA7deEf16f6b1BfC1bB5C89B7E4FAa91D9ebF7b"
 }

--- a/scripts/deployment/globals_optimism_mainnet_optimus2.json
+++ b/scripts/deployment/globals_optimism_mainnet_optimus2.json
@@ -20,7 +20,7 @@
   "requesterActivityCheckerAddress": "0x408dCA2b565f5eC7779C181870feFb51Ed67C3F4",
   "stakingFactoryAddress": "0xa45E64d13A30a51b91ae0eb182e88a40e9b18eD8",
   "stakingParams": {
-    "metadataHash": "",
+    "metadataHash": "0xb3145d86fb9e6fe9df6bc9f40ec514f91ebbdf74ee9a4f586b11177a53e64a8f",
     "maxNumServices": "40",
     "rewardsPerSecond": "1585489599188",
     "minStakingDeposit": "500000000000000000000",
@@ -38,5 +38,5 @@
     "serviceRegistry": "0x3d77596beb0f130a4415df3D2D8232B3d3D31e44",
     "activityChecker": "0x408dCA2b565f5eC7779C181870feFb51Ed67C3F4"
   },
-  "stakingTokenInstanceAddress": ""
+  "stakingTokenInstanceAddress": "0x746281b8fbDbd008729Dc9382392810F771B1BfD"
 }

--- a/scripts/deployment/globals_optimism_mainnet_optimus2.json
+++ b/scripts/deployment/globals_optimism_mainnet_optimus2.json
@@ -17,7 +17,7 @@
   "stakingTokenAddress": "0x63C2c53c09dE534Dd3bc0b7771bf976070936bAC",
   "mechMarketplaceAddress": "0x46C0D07F55d4F9B5Eed2Fc9680B5953e5fd7b461",
   "livenessRatio": "11337868480725",
-  "requesterActivityCheckerAddress": "",
+  "requesterActivityCheckerAddress": "0x408dCA2b565f5eC7779C181870feFb51Ed67C3F4",
   "stakingFactoryAddress": "0xa45E64d13A30a51b91ae0eb182e88a40e9b18eD8",
   "stakingParams": {
     "metadataHash": "",
@@ -36,7 +36,7 @@
     "configHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "proxyHash": "0xb89c1b3bdf2cf8827818646bce9a8f6e372885f8c55e5c07acbd307cb133b000",
     "serviceRegistry": "0x3d77596beb0f130a4415df3D2D8232B3d3D31e44",
-    "activityChecker": ""
+    "activityChecker": "0x408dCA2b565f5eC7779C181870feFb51Ed67C3F4"
   },
   "stakingTokenInstanceAddress": ""
 }

--- a/scripts/deployment/globals_optimism_mainnet_optimus3.json
+++ b/scripts/deployment/globals_optimism_mainnet_optimus3.json
@@ -20,7 +20,7 @@
   "requesterActivityCheckerAddress": "0x408dCA2b565f5eC7779C181870feFb51Ed67C3F4",
   "stakingFactoryAddress": "0xa45E64d13A30a51b91ae0eb182e88a40e9b18eD8",
   "stakingParams": {
-    "metadataHash": "",
+    "metadataHash": "0x5811984e49f5805714a23eed5fe5cc55f357849a912d0cd61baf692f15027e6d",
     "maxNumServices": "40",
     "rewardsPerSecond": "7927447995941",
     "minStakingDeposit": "2500000000000000000000",
@@ -38,5 +38,5 @@
     "serviceRegistry": "0x3d77596beb0f130a4415df3D2D8232B3d3D31e44",
     "activityChecker": "0x408dCA2b565f5eC7779C181870feFb51Ed67C3F4"
   },
-  "stakingTokenInstanceAddress": ""
+  "stakingTokenInstanceAddress": "0x5a4317A5695aD6E86744eFC824414cF899f07C68"
 }

--- a/scripts/deployment/globals_optimism_mainnet_optimus3.json
+++ b/scripts/deployment/globals_optimism_mainnet_optimus3.json
@@ -17,7 +17,7 @@
   "stakingTokenAddress": "0x63C2c53c09dE534Dd3bc0b7771bf976070936bAC",
   "mechMarketplaceAddress": "0x46C0D07F55d4F9B5Eed2Fc9680B5953e5fd7b461",
   "livenessRatio": "11337868480725",
-  "requesterActivityCheckerAddress": "",
+  "requesterActivityCheckerAddress": "0x408dCA2b565f5eC7779C181870feFb51Ed67C3F4",
   "stakingFactoryAddress": "0xa45E64d13A30a51b91ae0eb182e88a40e9b18eD8",
   "stakingParams": {
     "metadataHash": "",
@@ -36,7 +36,7 @@
     "configHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "proxyHash": "0xb89c1b3bdf2cf8827818646bce9a8f6e372885f8c55e5c07acbd307cb133b000",
     "serviceRegistry": "0x3d77596beb0f130a4415df3D2D8232B3d3D31e44",
-    "activityChecker": ""
+    "activityChecker": "0x408dCA2b565f5eC7779C181870feFb51Ed67C3F4"
   },
   "stakingTokenInstanceAddress": ""
 }

--- a/scripts/deployment/globals_polygon_mainnet_polystrat1.json
+++ b/scripts/deployment/globals_polygon_mainnet_polystrat1.json
@@ -18,7 +18,7 @@
   "requesterActivityCheckerAddress": "0x5B70A66fe68c4c86FFd724B58cc56049c70e9D3D",
   "stakingFactoryAddress": "0x46C0D07F55d4F9B5Eed2Fc9680B5953e5fd7b461",
   "stakingParams": {
-    "metadataHash": "",
+    "metadataHash": "0xc8b85320f15394583caff4160cdaf68e8e33105c311cc74c7f19d9da3d71d176",
     "maxNumServices": "100",
     "rewardsPerSecond": "158548959919",
     "minStakingDeposit": "50000000000000000000",
@@ -36,5 +36,5 @@
     "serviceRegistry": "0xE3607b00E75f6405248323A9417ff6b39B244b50",
     "activityChecker": "0x5B70A66fe68c4c86FFd724B58cc56049c70e9D3D"
   },
-  "stakingTokenInstanceAddress": ""
+  "stakingTokenInstanceAddress": "0x35C9C87a8caD9B7fd9d367Eb4Fd287365688E000"
 }

--- a/scripts/deployment/globals_polygon_mainnet_polystrat1.json
+++ b/scripts/deployment/globals_polygon_mainnet_polystrat1.json
@@ -34,7 +34,7 @@
     "configHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "proxyHash": "0x92565062fdea8761e07d9df2fcdbd66c0582af6ddf0e0355bc07754ad97400b0",
     "serviceRegistry": "0xE3607b00E75f6405248323A9417ff6b39B244b50",
-    "activityChecker": ""
+    "activityChecker": "0x5B70A66fe68c4c86FFd724B58cc56049c70e9D3D"
   },
   "stakingTokenInstanceAddress": ""
 }

--- a/scripts/deployment/globals_polygon_mainnet_polystrat2.json
+++ b/scripts/deployment/globals_polygon_mainnet_polystrat2.json
@@ -15,7 +15,7 @@
   "stakingTokenAddress": "0x4aba1Cf7a39a51D75cBa789f5f21cf4882162519",
   "mechMarketplaceAddress": "0x343F2B005cF6D70bA610CD9F1F1927049414B582",
   "livenessRatio": "11337868480725",
-  "requesterActivityCheckerAddress": "",
+  "requesterActivityCheckerAddress": "0x5B70A66fe68c4c86FFd724B58cc56049c70e9D3D",
   "stakingFactoryAddress": "0x46C0D07F55d4F9B5Eed2Fc9680B5953e5fd7b461",
   "stakingParams": {
     "metadataHash": "",
@@ -34,7 +34,7 @@
     "configHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "proxyHash": "0x92565062fdea8761e07d9df2fcdbd66c0582af6ddf0e0355bc07754ad97400b0",
     "serviceRegistry": "0xE3607b00E75f6405248323A9417ff6b39B244b50",
-    "activityChecker": ""
+    "activityChecker": "0x5B70A66fe68c4c86FFd724B58cc56049c70e9D3D"
   },
   "stakingTokenInstanceAddress": ""
 }

--- a/scripts/deployment/globals_polygon_mainnet_polystrat2.json
+++ b/scripts/deployment/globals_polygon_mainnet_polystrat2.json
@@ -18,7 +18,7 @@
   "requesterActivityCheckerAddress": "0x5B70A66fe68c4c86FFd724B58cc56049c70e9D3D",
   "stakingFactoryAddress": "0x46C0D07F55d4F9B5Eed2Fc9680B5953e5fd7b461",
   "stakingParams": {
-    "metadataHash": "",
+    "metadataHash": "0xb1ed853024b26ae433d37f103db748147f8063bd630dbc660c3662dfa4e5fb9d",
     "maxNumServices": "50",
     "rewardsPerSecond": "1585489599188",
     "minStakingDeposit": "500000000000000000000",
@@ -36,5 +36,5 @@
     "serviceRegistry": "0xE3607b00E75f6405248323A9417ff6b39B244b50",
     "activityChecker": "0x5B70A66fe68c4c86FFd724B58cc56049c70e9D3D"
   },
-  "stakingTokenInstanceAddress": ""
+  "stakingTokenInstanceAddress": "0xD7F69649691039E86F15153c7BD567aA0049d122"
 }

--- a/scripts/deployment/globals_polygon_mainnet_polystrat3.json
+++ b/scripts/deployment/globals_polygon_mainnet_polystrat3.json
@@ -15,7 +15,7 @@
   "stakingTokenAddress": "0x4aba1Cf7a39a51D75cBa789f5f21cf4882162519",
   "mechMarketplaceAddress": "0x343F2B005cF6D70bA610CD9F1F1927049414B582",
   "livenessRatio": "11337868480725",
-  "requesterActivityCheckerAddress": "",
+  "requesterActivityCheckerAddress": "0x5B70A66fe68c4c86FFd724B58cc56049c70e9D3D",
   "stakingFactoryAddress": "0x46C0D07F55d4F9B5Eed2Fc9680B5953e5fd7b461",
   "stakingParams": {
     "metadataHash": "",
@@ -34,7 +34,7 @@
     "configHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "proxyHash": "0x92565062fdea8761e07d9df2fcdbd66c0582af6ddf0e0355bc07754ad97400b0",
     "serviceRegistry": "0xE3607b00E75f6405248323A9417ff6b39B244b50",
-    "activityChecker": ""
+    "activityChecker": "0x5B70A66fe68c4c86FFd724B58cc56049c70e9D3D"
   },
   "stakingTokenInstanceAddress": ""
 }

--- a/scripts/deployment/globals_polygon_mainnet_polystrat3.json
+++ b/scripts/deployment/globals_polygon_mainnet_polystrat3.json
@@ -18,7 +18,7 @@
   "requesterActivityCheckerAddress": "0x5B70A66fe68c4c86FFd724B58cc56049c70e9D3D",
   "stakingFactoryAddress": "0x46C0D07F55d4F9B5Eed2Fc9680B5953e5fd7b461",
   "stakingParams": {
-    "metadataHash": "",
+    "metadataHash": "0xbe9dd9ab80500d4d444f44ba88f7244e6a07a2a830500850f5ae08280ae66672",
     "maxNumServices": "50",
     "rewardsPerSecond": "15854895991882",
     "minStakingDeposit": "5000000000000000000000",
@@ -36,5 +36,5 @@
     "serviceRegistry": "0xE3607b00E75f6405248323A9417ff6b39B244b50",
     "activityChecker": "0x5B70A66fe68c4c86FFd724B58cc56049c70e9D3D"
   },
-  "stakingTokenInstanceAddress": ""
+  "stakingTokenInstanceAddress": "0x7dbF10769CA7528ec9aA440b668C716Caf08e7EA"
 }


### PR DESCRIPTION
## Summary

Finalizes the staking-config rollout: wires the deployed `RequesterActivityCheckerV2` (one per chain) into all 17 configs, and records the deployed staking-instance addresses + on-chain `metadataHash` as each program goes live.

## V2 activity checker (one per chain, propagated to all configs)

Within each chain all configs share the same `mechMarketplaceAddress` + `livenessRatio`, so a single checker serves the chain. Set on both `requesterActivityCheckerAddress` and `stakingParams.activityChecker`:

| Chain | V2 checker | Configs |
|---|---|---|
| Gnosis | `0x3514EeA47C03dF8d9FdD68A469908755d2870c48` | omenstrat1..8 |
| Polygon | `0x5B70A66fe68c4c86FFd724B58cc56049c70e9D3D` | polystrat1..3 |
| Optimism | `0x408dCA2b565f5eC7779C181870feFb51Ed67C3F4` | optimus1..3 |
| Base | `0xE73C4e90983aa65d42b2de968E0C8F25Ced835A8` | basius1..3 |

## Deployed staking instances (address + metadataHash)

`metadataHash` read on-chain; each contract's `rewardsPerSecond` + `minStakingDeposit` verified to match its config tier before recording.

| Program | Staking instance | metadataHash |
|---|---|---|
| Omenstrat I | `0x1E215da0541B4a77a66e21F17413A877B84Ab129` | `0x9bcbe5…cbd0f3` |
| Omenstrat II | `0xC2BbfC0d2F5a341DcdCc9f3B78FAF7B04f0244ff` | `0x1ab051…6c40db` |
| Omenstrat III | `0xABD4f159a088E7f18FEE8241cF9367f1d746780f` | `0x1d9d1b…01264a` |
| Omenstrat IV | `0xc9940B9dACA9FDf1B0cD6dE8e3D25ddDC8C9fd0D` | `0x24c0cb…b5e0cc` |
| Omenstrat V | `0x93aAA7155942700cad74c250263fB2D0c6F72B27` | `0xf33649…127377` |
| Omenstrat VI | `0xB7ab6F7e6993Df1f0c6A9B177B169Faf4b0C9CCa` | `0x2e8255…c73330` |
| Omenstrat VII | `0xB801FD1728Eef27418FE03720b1FF3E769F35152` | `0x4f16d6…608756` |
| Optimus I | `0xCDA7deEf16f6b1BfC1bB5C89B7E4FAa91D9ebF7b` | `0x3fd5ca…69d1b3` |
| Optimus II | `0x746281b8fbDbd008729Dc9382392810F771B1BfD` | `0xb3145d…e64a8f` |
| Optimus III | `0x5a4317A5695aD6E86744eFC824414cF899f07C68` | `0x581198…027e6d` |
| Polystrat I | `0x35C9C87a8caD9B7fd9d367Eb4Fd287365688E000` | `0xc8b853…71d176` |
| Polystrat II | `0xD7F69649691039E86F15153c7BD567aA0049d122` | `0xb1ed85…e5fb9d` |
| Polystrat III | `0x7dbF10769CA7528ec9aA440b668C716Caf08e7EA` | `0xbe9dd9…e66672` |
| Basius I | `0x0fB55CEf7B12B76ea52900325461a5443F51B43F` | `0x51df66…f7dfd1` |
| Basius II | `0x728ca3b024Ba4c273695Df6e45e79DB675B8c756` | `0x75aead…eb9d7d` |
| Basius III | `0x9593C4524DF86f46935aa0eC996B4ccBe71c8234` | `0xb20a87…c0a90b` |

**Omenstrat VIII** is on hold (same tier as Omenstrat I) — its `stakingTokenInstanceAddress` / `metadataHash` remain empty.
