### PR TITLE
docs: record per-entry status and this list's scope

### DIFF
--- a/docs/Vulnerabilities_list_staking_programmes.md
+++ b/docs/Vulnerabilities_list_staking_programmes.md
@@ -18,9 +18,22 @@
 
 ## Involved contracts and level of the bugs
 
-This document records known issues in the `autonolas-staking-programmes` contracts — deliberately
-unfixed design trade-offs and accepted risks, each paired with its operational or contract-level
-mitigation. Entries here are found in the current `main` sources.
+This document records known issues in the `autonolas-staking-programmes` contracts, each paired with
+its operational or contract-level mitigation. Entries here are found in the current `main` sources.
+
+**Two clarifications about what this list is.**
+
+*Status varies per entry.* Unlike the sibling repositories' lists, not every entry here is a
+deliberately-unfixed trade-off that has been accepted. Several are identified defects with a
+recommended code fix and no acceptance decision recorded. Each entry therefore carries a **Status**
+line: `accepted` (a trade-off we are keeping), `fix pending` (a defect awaiting a change), or
+`fixed in source, pending redeployment`. Read the status before treating an entry as an accepted risk.
+
+*Scope.* This repository is not currently among those whose vulnerabilities lists the public Olas
+bug-bounty programme enumerates in its known-issues clause, and these contracts do not currently
+appear in that programme's assets-in-scope. This file is therefore an internal engineering record, and
+an entry here does not by itself make a report about it ineligible. If this repository is brought into
+scope, this list should be added to that clause at the same time.
 
 | Contract | Level |
 |---|---|
@@ -37,6 +50,7 @@ mitigation. Entries here are found in the current `main` sources.
 
 **Severity**: Low
 **Source**: internal review
+**Status**: fix pending
 
 `RegistryTracker.registerServiceMultisig` guards against re-registration by the service **multisig**:
 
@@ -63,6 +77,7 @@ marker) so a service Id is eligible once regardless of multisig rotation.
 
 **Severity**: Low
 **Source**: internal review
+**Status**: fix pending
 
 `RegistryTracker.registerServiceMultisig` verifies the staking instance only by a nonzero implementation:
 
@@ -88,6 +103,7 @@ campaign can exclude disabled instances in the interim.
 
 **Severity**: Low
 **Source**: internal review
+**Status**: fix pending
 
 `DualStakingToken.restake()` recovers an `Evicted` service by calling the base unstake, but discards the
 returned reward and never runs the second-token conversion:
@@ -116,6 +132,7 @@ protocol drain, and a staker can `unstake` (which does convert) and re-stake man
 
 **Severity**: Low
 **Source**: internal review
+**Status**: fix pending
 
 `DualStakingToken.unstake()` clears the multisig activity marker before delegating to the base:
 
@@ -141,6 +158,7 @@ unstake/checkpoint (or checkpoint before clearing), so the pending period is cre
 
 **Severity**: Low
 **Source**: internal review
+**Status**: fix pending
 
 The V1 `RequesterActivityChecker` reports `[Safe nonce, mapRequestCounts(requester)]` and requires the
 request-count delta to be backed by the requester Safe's nonce growth. In the signed-delivery flow the mech
@@ -158,6 +176,7 @@ affected), and the resolution is simply to use V2, which the protocol already do
 
 **Severity**: Low
 **Source**: internal review
+**Status**: fix pending
 
 `MechActivityChecker` reports `[Safe nonce, mapMechServiceDeliveryCounts(multisig)]` and enforces
 `(cur[1] - last[1]) <= (cur[0] - last[0])` — every delivery-count increment must be backed by a service-Safe
@@ -175,6 +194,7 @@ item 7 — relaxing it would re-open self-generated count inflation — so it is
 
 **Severity**: Low
 **Source**: internal review
+**Status**: fix pending
 
 The staking liveness KPI rewards a service for on-chain mech usage above a threshold
 (`ratio >= livenessRatio`). Because genuine and self-generated usage are indistinguishable on-chain, a
@@ -198,6 +218,7 @@ programme.
 
 **Severity**: Low
 **Source**: internal review
+**Status**: fix pending
 
 A mixed Nevermined delivery batch can include zero-rate entries that are still marked `Delivered` and counted
 in `mapMechDeliveryCounts` / `mapMechServiceDeliveryCounts`, while only the positive-rate entry settles
@@ -213,6 +234,7 @@ decline to count zero-rate entries toward activity, or require a minimum deliver
 
 **Severity**: Low
 **Source**: internal review
+**Status**: fix pending
 
 `claimAll()` runs two loops. The first loop zeroes every funded entitlement (`mapServiceIdAirdropAmount[id]
 = 0`) and accumulates the total. The second loop resolves each service's multisig and, if the service is
@@ -231,6 +253,7 @@ retains its claim for a later call. Applies before the airdrop is deployed; no l
 
 **Severity**: Low
 **Source**: internal review
+**Status**: fix pending
 
 Neither `claim()` nor `claimAll()` checks the service state before paying: they resolve the service's
 current multisig and transfer to it. A service that has been terminated (or otherwise parked) still resolves
@@ -247,6 +270,7 @@ Applies before the airdrop is deployed; no live exposure today.
 
 **Severity**: Low
 **Source**: internal review
+**Status**: fix pending
 
 The `token == olas` staking-token check lives only on the create-and-stake path (in the shared parameter
 check). The existing-service entry point `Contributors.stake(socialId, serviceId, stakingInstance)`


### PR DESCRIPTION
Follow-up to #151, addressing two points raised in review there that were not resolved before merge. Documentation only.

## Per-entry status

The header described the file as recording *"deliberately unfixed design trade-offs and accepted risks, each paired with its … mitigation"* — the framing the sibling lists use. That does not describe these entries. All eleven carry a recommended **code fix** (gate by `serviceId`, use `verifyInstance`, capture and `_claim` before re-staking, clear the marker after the base checkpoint, and so on) with no decision recorded that the trade-off has been accepted. They are identified defects awaiting a fix.

Each entry now carries an explicit `**Status**` line — `accepted`, `fix pending`, or `fixed in source, pending redeployment` — seeded as `fix pending` throughout, which is what the entry texts currently describe. This answers the question someone will ask later: *is item 3 a decision, or a to-do?* Anything genuinely accepted should be flipped to `accepted` deliberately rather than by default.

## What this list is, for scope purposes

The file adopts the filename pattern, header framing and structure of the four `Vulnerabilities_list_*.md` documents the public Olas bug-bounty programme treats as authoritative in its known-issues clause. But that clause enumerates four specific repositories — governance, marketplace, registries, tokenomics — and this repository is not among them, nor do these contracts appear in the programme's assets-in-scope.

So today an entry here does not by itself make a report about it ineligible. The header now states that plainly, and notes that if this repository is brought into scope the list should be added to that clause at the same time. That keeps the file honest about its own authority rather than leaving the question to be resolved during a dispute.

No contract source touched.
