### PR TITLE
ci: pin the Foundry toolchain to v1.7.1 instead of tracking nightly

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -25,7 +25,14 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          # Pinned to a semver release, not `nightly`. Tracking `nightly` made CI depend on an
+          # unvetted daily build: foundryup resolves a nightly tag whose linux-amd64 asset may
+          # never have been published (HTTP 404), and every job in the repo then fails on an
+          # upstream change with no commit of ours involved. A floating toolchain also means the
+          # runner that validates the contracts can change silently between a review and a merge,
+          # which this repo already avoids for solc.
+          # Bump deliberately, as a reviewable one-line change.
+          version: v1.7.1
 
       # Run linters
       - name: Run ESLint


### PR DESCRIPTION
`foundryup` resolves the workflow's `version: nightly` to a build whose `linux_amd64` asset returns **HTTP 404**, so every job fails on an upstream change with no commit of ours involved:

```
Error:
   0: failed to download https://github.com/foundry-rs/foundry/releases/download/
      nightly-<sha>/foundry_nightly_linux_amd64.tar.gz: HTTP 404 Not Found
```

This repo's last `main` run predates the asset disappearing, so CI isn't red yet — it will be on the next push.

Pins to `v1.7.1`, matching **`autonolas-tokenomics`** ([`627d05d`](https://github.com/valory-xyz/autonolas-tokenomics/commit/627d05da), 2026-08-14) and **`autonolas-registries`** (#313), both of which hit exactly this and resolved it the same way. Both are green on the pin, and `v1.7.1` is verified to still publish a `linux_amd64` asset.

Beyond unbreaking the build: a floating toolchain means the runner that validates the contracts can change silently between a review and a merge — the same reason solc is pinned rather than floated. Bumping is now a deliberate, reviewable one-line change.

The rationale comment travels with the pin so the next person to touch it knows why it isn't `nightly`.
